### PR TITLE
Add aarch64 support on Linux

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -44,7 +44,11 @@ install_tool() {
 
 get_platform() {
 	if [ "$(uname)" = "Linux" ]; then
-		echo "$(uname -m)-unknown-linux-gnu"
+		if [ "$(uname -m)" = "aarch64" ]; then
+			echo "aarch64-unknown-linux-musl"
+		else
+			echo "$(uname -m)-unknown-linux-gnu"
+		fi
 	elif [ "$(uname)" = "Darwin" ]; then
 		echo "$(uname -m)-apple-darwin"
 	else

--- a/bin/install
+++ b/bin/install
@@ -44,8 +44,8 @@ install_tool() {
 
 get_platform() {
 	if [ "$(uname)" = "Linux" ]; then
-		if [ "$(uname -m)" = "aarch64" ]; then
-			echo "aarch64-unknown-linux-musl"
+		if [ "$(grep -oP '^ID=\K\w+' /etc/os-release)" = "alpine" ]; then
+			echo "$(uname -m)-unknown-linux-musl"
 		else
 			echo "$(uname -m)-unknown-linux-gnu"
 		fi


### PR DESCRIPTION
Hi @mpalmer,

Thank you for the plugin.

Unfortunately it doesn't work for me (running ARM64 linux), although mdbook has pre-built binaries for my arch since https://github.com/rust-lang/mdBook/pull/1862.

Please consider merging this PR.

Thanks,
Mate